### PR TITLE
Update TinyEXIF.h

### DIFF
--- a/libs/TinyEXIF.h
+++ b/libs/TinyEXIF.h
@@ -57,6 +57,7 @@
 #include <string>
 #include <vector>
 #include <GSLAM/core/Svar.h>
+#include <math.h>
 
 namespace TinyEXIF {
 


### PR DESCRIPTION
solving ‘fabs’ was not declared in this scope